### PR TITLE
fix: typo on Strapi url and missing dependency

### DIFF
--- a/packages/ra-strapi/README.md
+++ b/packages/ra-strapi/README.md
@@ -1,6 +1,6 @@
 # ra-strapi
 
-This package provides a Data Provider and an Auth Provider to integrate [Strapi](https:/strapi.io/) with [react-admin](https://marmelab.com/react-admin).
+This package provides a Data Provider and an Auth Provider to integrate [Strapi](https://strapi.io/) with [react-admin](https://marmelab.com/react-admin).
 
 This package supports:
 

--- a/packages/ra-strapi/package.json
+++ b/packages/ra-strapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ra-strapi",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "repository": "git@github.com:marmelab/ra-strapi.git",
   "author": "Guillaume BILLEY",
   "license": "MIT",

--- a/packages/ra-strapi/package.json
+++ b/packages/ra-strapi/package.json
@@ -17,7 +17,8 @@
   "types": "esm/index.d.ts",
   "sideEffects": false,
   "dependencies": {
-    "lodash": "^4.17.21"
+    "lodash": "^4.17.21",
+    "qs": "^6.14.0"
   },
   "peerDependencies": {
     "react-admin": "^5.0.0"


### PR DESCRIPTION
- The Strapi url was missing a `/` leading to a bad url on the npmjs documentation.
- The `qs` dependency was missing