### PR TITLE
fix: pass apiKey in the httpClient function

### DIFF
--- a/packages/demo-react-admin/.env
+++ b/packages/demo-react-admin/.env
@@ -1,1 +1,2 @@
 VITE_STRAPI_URL=http://localhost:1337
+VITE_STRAPI_API_KEY=my-api-key

--- a/packages/ra-strapi/README.md
+++ b/packages/ra-strapi/README.md
@@ -72,8 +72,7 @@ export const App = () => (
 
 ### Using an API key
 
-Create an httpClient with `strapiHttpClient`, specifying the authType to `apiKey`.
-Make sure to have a environment variable `STRAPI_API_KEY` containing the API key.
+Create an httpClient with `strapiHttpClient`, specifying the authType to `apiKey` and the key.
 Create a dataProvider giving the baseURL of your Stapi instance, and the httpClient you created.
 
 ```tsx
@@ -82,7 +81,8 @@ import { Admin, ListGuesser, LoginWithEmail, Resource } from "react-admin";
 import { Layout } from "./Layout";
 
 const STRAPI_URL = import.meta.env.VITE_STRAPI_URL;
-const httpClient = strapiHttpClient({ authType: "apiKey" });
+const STRAPI_API_KEY = import.meta.env.VITE_STRAPI_API_KEY;
+const httpClient = strapiHttpClient({ authType: "apiKey", apiKey:  STRAPI_API_KEY});
 const dataProvider = strapiDataProvider({ baseURL: STRAPI_URL, httpClient });
 export const App = () => (
   <Admin layout={Layout} dataProvider={dataProvider} loginPage={LoginWithEmail}>

--- a/packages/ra-strapi/src/strapiHttpClient.ts
+++ b/packages/ra-strapi/src/strapiHttpClient.ts
@@ -18,7 +18,7 @@ export type StrapiHttpClientParams = {
  * ```
  * or
  * ```ts
- * const httpClient = strapiHttpClient({ authType : "apiKey" }); // If you want to use API Key authentication, it will use the STRAPI_API_KEY environment variable
+ * const httpClient = strapiHttpClient({ authType : "apiKey", apiKey: "MyAPIKey" });
  * ```
  */
 export const strapiHttpClient = (params?: StrapiHttpClientParams): any => {

--- a/packages/ra-strapi/src/strapiHttpClient.ts
+++ b/packages/ra-strapi/src/strapiHttpClient.ts
@@ -3,6 +3,7 @@ import { STRAPI_JWT_KEY } from "./strapiAuthProvider";
 
 export type StrapiHttpClientParams = {
   authType?: "jwt" | "apiKey";
+  apiKey?: string;
   storage?: Storage;
 };
 /**
@@ -22,11 +23,12 @@ export type StrapiHttpClientParams = {
  */
 export const strapiHttpClient = (params?: StrapiHttpClientParams): any => {
   const authType = params?.authType || "jwt";
+  const apiKey = params?.apiKey;
   const storage = params?.storage || localStorage;
 
   const getAuthorizationToken = () => {
     if (!authType) return {};
-    if (authType === "apiKey" && !process.env.STRAPI_API_KEY) {
+    if (authType === "apiKey" && !apiKey) {
       throw new Error(
         "To use the apiKey authentication, you need to set the STRAPI_API_KEY environment variable"
       );
@@ -35,7 +37,7 @@ export const strapiHttpClient = (params?: StrapiHttpClientParams): any => {
     const token =
       authType === "jwt"
         ? storage.getItem(STRAPI_JWT_KEY)
-        : process.env.STRAPI_API_KEY;
+        : apiKey;
     return {
       authenticated: !!token,
       token: `Bearer ${token}`,


### PR DESCRIPTION
- [ ] Pass explicitly the apiKey instead of using a var env
- [ ] update the documentation